### PR TITLE
Fix WC 3.0 Orders Compability Issue

### DIFF
--- a/classes/woocommerce.class.php
+++ b/classes/woocommerce.class.php
@@ -104,7 +104,7 @@ class MailsterWooCommerce {
 	/**
 	 *
 	 *
-	 * @param unknown $settings
+	 * @param array $settings
 	 * @return unknown
 	 */
 	public function settings_tab( $settings ) {
@@ -209,12 +209,11 @@ class MailsterWooCommerce {
 		if ( ! isset( $order->billing_email ) ) {
 			return;
 		}
-
 		$default_lists = mailster_option( 'woocommerce_lists', array() );
 
-		$email = $order->billing_email;
-		$firstname = $order->billing_first_name;
-		$lastname = $order->billing_last_name;
+		$email = $order->get_billing_email();
+		$firstname = $order->get_billing_first_name();
+		$lastname = $order->get_billing_last_name();
 
 		foreach ( $order->get_items() as $item ) {
 
@@ -233,7 +232,7 @@ class MailsterWooCommerce {
 				'firstname' => $firstname,
 				'lastname' => $lastname,
 				'email' => $email,
-				'referer' => sprintf( '<a href="' . admin_url( 'post.php?post=%d&action=edit' ) . '">%s #%d</a>', $order->id, __( 'Order', 'mailster-woocommerce' ), $order->id ),
+				'referer' => sprintf( '<a href="' . admin_url( 'post.php?post=%d&action=edit' ) . '">%s #%d</a>', $order->get_id(), __( 'Order', 'mailster-woocommerce' ), $order->get_id() ),
 				'status' => mailster_options( 'woocommerce-double-opt-in' ) ? 0 : 1,
 			);
 


### PR DESCRIPTION
Fixing error: "billing_email was called incorrectly. Order properties should not be accessed directly. Backtrace: require('wp-blog-header.php'), require_once('wp-includes/template-loader.php'), do_action('template_redirect'), WP_Hook->do_action, WP_Hook->apply_filters, WC_AJAX::do_wc_ajax, do_action('wc_ajax_checkout'), WP_Hook->do_action, WP_Hook->apply_filters, WC_AJAX::checkout, WC_Checkout->process_checkout, WC_Checkout->create_order, do_action('woocommerce_checkout_update_order_meta'), WP_Hook->do_action, WP_Hook->apply_filters, MailsterWooCommerce->on_checkout, MailsterWooCommerce->subscribe, WC_Abstract_Legacy_Order->__get, wc_doing_it_wrong."